### PR TITLE
Add support for selector instead of [block]

### DIFF
--- a/cypress/e2e/block.cy.js
+++ b/cypress/e2e/block.cy.js
@@ -236,4 +236,41 @@ context('Pattern Css', () => {
 				.and('have.css', 'color', 'rgb(255, 0, 0)');
 		});
 	});
+	it('Supports "selector" in addition to [block]', () => {
+		cy.window().then((win) => {
+			// Manually add blocks so we can get the block id
+			const block = win.wp.blocks.createBlock('core/paragraph', {
+				content: 'Hello',
+			});
+			const className = `pcss-${block.clientId?.split('-')[0]}`;
+			win.wp.data.dispatch('core/block-editor').insertBlock(block);
+
+			// Select the block
+			cy.selectBlockById(block.clientId);
+			cy.clearCodeFromCurrentBlock(); // clear placeholder
+			cy.addCodeToCurrentBlock(`
+				[block] { color: red; }
+				selector { border-bottom: 1px solid green; }
+			`);
+
+			// p tag should be red
+			cy.get(`.${className}`).should(
+				'have.css',
+				'color',
+				'rgb(255, 0, 0)',
+			);
+
+			// p tag should have green border
+			cy.get(`.${className}`).should(
+				'have.css',
+				'border-bottom',
+				'1px solid rgb(0, 128, 0)',
+			);
+
+			// Make sure the 'line-error' class isn't there
+			cy.get('[data-cy="pcss-editor-block"] pre .line-error').should(
+				'not.exist',
+			);
+		});
+	});
 });

--- a/cypress/e2e/block.cy.js
+++ b/cypress/e2e/block.cy.js
@@ -236,8 +236,13 @@ context('Pattern Css', () => {
 				.and('have.css', 'color', 'rgb(255, 0, 0)');
 		});
 	});
-	it('Supports "selector" in addition to [block]', () => {
+	it('Supports custom selectors in addition to [block]', () => {
 		cy.window().then((win) => {
+			// Override usually by php but can mutate the window anyway
+			win.patternCss.selectorOverride = {
+				name: 'selector',
+				type: 'type',
+			};
 			// Manually add blocks so we can get the block id
 			const block = win.wp.blocks.createBlock('core/paragraph', {
 				content: 'Hello',

--- a/pattern-css.php
+++ b/pattern-css.php
@@ -37,6 +37,8 @@ add_action('enqueue_block_editor_assets', function () {
         'window.patternCss = ' . wp_json_encode([
             'canEditCss' => current_user_can('edit_css'),
             'pluginUrl' => esc_url_raw(plugin_dir_url(__FILE__)),
+			'selectorOverride' => defined('PATTERN_CSS_SELECTOR_OVERRIDE') ?
+				PATTERN_CSS_SELECTOR_OVERRIDE : null,
         ]) . ';',
         'before'
     );

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ Add custom CSS to any block or pattern, including reusable patterns too. Your st
 - Use `!important` to override your theme styles (use sparingly)
 
 = Features =
-- Scopes styles to the block so that parent/sibling blocks arent affected
+- Scopes styles to the block so that parent/sibling blocks are not affected
 - It's fast. CSS is minified and optimized in the browser
 - It's safe. Invalid, non-spec CSS is never persisted (validated via webassembly sandbox)
 - Supports reusable (synced or not-synced) patterns
@@ -75,6 +75,13 @@ Star it on [GitHub](https://github.com/KevinBatdorf/pattern-css)
 
 1. Activate the plugin through the 'Plugins' screen in WordPress
 
+== Frequently Asked Questions ==
+
+= Use something other than [block] =
+
+You can add a custom selector via a PHP constant. It requires setting a type (type, attribute, etc) and the name. Here's an example for `selector {}`. Add this to functions.php:
+`define('PATTERN_CSS_SELECTOR_OVERRIDE', ['name' => 'selector', 'type' => 'type']);`
+
 == Screenshots ==
 
 1. Add styles not available in the editor
@@ -82,6 +89,8 @@ Star it on [GitHub](https://github.com/KevinBatdorf/pattern-css)
 3. Will warn you if your CSS is invalid
 
 == Changelog ==
+
+- Lets users define an additional block selector
 
 = 1.1.0 - 2024-02-18 =
 - Prevent adding classes to blocks unless CSS is added

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ Add custom CSS to any block or pattern, including reusable patterns too. Your st
 - Every block will have a new "Additional CSS" settings panel.
 - To target a block, you must use the `[block]` selector.
 - To target any element *inside* the block, use the normal CSS selector.
-- Use `!important` if needed to override your theme styles (use sparingly)
+- Use `!important` to override your theme styles (use sparingly)
 
 = Features =
 - Scopes styles to the block so that parent/sibling blocks arent affected
@@ -28,6 +28,16 @@ Add custom CSS to any block or pattern, including reusable patterns too. Your st
 - Minifies colors and math functions to simplify according to spec
 
 Star it on [GitHub](https://github.com/KevinBatdorf/pattern-css)
+
+= Basic Example =
+`[block] a {
+  border-bottom: 1px solid blue;
+}
+[block] a:hover {
+  border-bottom-color: green;
+}
+/* Output: */
+.pcss-f526bb2d a{border-bottom:1px solid #00f}.pcss-f526bb2d a:hover{border-bottom-color:green}`
 
 = Supports Media Queries =
 `@media (prefers-color-scheme: dark) {
@@ -60,7 +70,6 @@ Star it on [GitHub](https://github.com/KevinBatdorf/pattern-css)
 
 /* Output: */
 .pcss-3aa0f0fc{padding:5px 5px 15px 50px}`
-
 
 == Installation ==
 

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -72,10 +72,12 @@ export const BlockControl = (
 							name?: string;
 							type: string;
 						};
-						// If the selector is [block] or selector then just swap it with pcssClassId
+						const { name: overrideName, type: overrideType } =
+							window.patternCss.selectorOverride || {};
+						// If the selector is [block] or custom then just swap it with pcssClassId
 						if (
 							(type === 'attribute' && name === 'block') ||
-							(type === 'type' && name === 'selector')
+							(type === overrideType && name === overrideName)
 						) {
 							return [
 								{

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -38,7 +38,6 @@ export const BlockControl = (
 	const [transformed, setTransformed] = useState<Uint8Array>();
 	const [compiled, setCompiled] = useState(compiledCss || '');
 	const hasPermission = useMemo(() => window?.patternCss?.canEditCss, []);
-	console.log({ compiled });
 	const stringOne = __('Examples', 'pattern-css');
 
 	/* translators: "An example of css that will focus on the block itself" */
@@ -67,16 +66,12 @@ export const BlockControl = (
 				minify: true,
 				errorRecovery: true,
 				visitor: {
-					RuleExit: (f) => {
-						console.log({ f });
-					},
 					Selector(selector) {
 						const { name, type } = selector[0] as {
 							// cast as we only deal with cases where names exist
 							name?: string;
 							type: string;
 						};
-						console.log('selector', selector, name, type);
 						// If the selector is [block] or selector then just swap it with pcssClassId
 						if (
 							(type === 'attribute' && name === 'block') ||

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -38,7 +38,7 @@ export const BlockControl = (
 	const [transformed, setTransformed] = useState<Uint8Array>();
 	const [compiled, setCompiled] = useState(compiledCss || '');
 	const hasPermission = useMemo(() => window?.patternCss?.canEditCss, []);
-
+	console.log({ compiled });
 	const stringOne = __('Examples', 'pattern-css');
 
 	/* translators: "An example of css that will focus on the block itself" */
@@ -67,14 +67,24 @@ export const BlockControl = (
 				minify: true,
 				errorRecovery: true,
 				visitor: {
+					RuleExit: (f) => {
+						console.log({ f });
+					},
 					Selector(selector) {
-						// If the selector is [block] then just swap it with pcssClassId
+						const { name, type } = selector[0] as {
+							// cast as we only deal with cases where names exist
+							name?: string;
+							type: string;
+						};
+						console.log('selector', selector, name, type);
+						// If the selector is [block] or selector then just swap it with pcssClassId
 						if (
-							selector[0]?.type === 'attribute' &&
-							selector[0]?.name === 'block'
+							(type === 'attribute' && name === 'block') ||
+							(type === 'type' && name === 'selector')
 						) {
 							return [
 								{
+									...selector[0],
 									type: 'class',
 									// eslint-disable-next-line
 									name: pcssClassId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ declare global {
 			canEditCss: string;
 			pluginUrl: string;
 			transform: typeof transform;
+			selectorOverride?: {
+				type: string;
+				name: string;
+			};
 		};
 	}
 }


### PR DESCRIPTION
Adds support for adding custom selectors, in case you don't want to use `[block]`

Context here: https://wordpress.org/support/topic/suggestion-take-a-look-at-otter-blocks-custom-css-component/