### PR TITLE
Remove demo code on focus

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,8 @@ Star it on [GitHub](https://github.com/KevinBatdorf/pattern-css)
 
 == Changelog ==
 
+- Removes the code example on focus and adds it back on blur (if empty)
+
 = 1.1.0 - 2024-02-18 =
 - Prevent adding classes to blocks unless CSS is added
 - Force the settings area to the bottom (mainly for custom blocks)

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -181,6 +181,16 @@ export const BlockControl = (
 								value={css ?? defaultCssExample}
 								data-cy="pcss-editor-block"
 								onChange={handleChange}
+								onFocus={(e) => {
+									if (e.target.value === defaultCssExample) {
+										handleChange('');
+									}
+								}}
+								onBlur={(e) => {
+									if (e.target.value === '') {
+										handleChange(defaultCssExample);
+									}
+								}}
 								lineOptions={warnings.map(({ loc }) => ({
 									line: loc.line,
 									classes: ['line-error'],
@@ -189,7 +199,7 @@ export const BlockControl = (
 							<p className="m-0 my-2 text-gray-700 text-xs">
 								{sprintf(
 									__(
-										'Styles will be scoped to this block only. See the readme for some examples.',
+										'See the plugin readme for examples.',
 										'pattern-css',
 									),
 									'`[block]`',

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -7,11 +7,22 @@ import type { LineOption } from '../types';
 type CodeEditorProps = {
 	value: string;
 	onChange: (value: string) => void;
+	// eslint-disable-next-line
+	onFocus: (event: any) => void;
+	// eslint-disable-next-line
+	onBlur: (event: any) => void;
 	lineOptions: LineOption[];
 };
 export const CodeEditor = (props: CodeEditorProps) => {
 	const textAreaRef = useRef<HTMLDivElement>(null);
-	const { value, onChange, lineOptions = [], ...remainingProps } = props;
+	const {
+		value,
+		onChange,
+		onFocus,
+		onBlur,
+		lineOptions = [],
+		...remainingProps
+	} = props;
 	const {
 		highlighter,
 		error: editorError,
@@ -49,6 +60,8 @@ export const CodeEditor = (props: CodeEditorProps) => {
 					// Tab lock here. Pressing Escape will unlock.
 					textAreaRef.current?.querySelector('textarea')?.focus()
 				}
+				onFocus={onFocus}
+				onBlur={onBlur}
 				highlight={(code: string) =>
 					highlighter
 						?.codeToHtml(decodeEntities(code), {


### PR DESCRIPTION
This adds support for hiding the example code when focusing on the text. It's only helpful as a quick tutorial and can be annoying after the 2nd or 3rd time having to clear it out.

resolves: https://wordpress.org/support/topic/suggestion-take-a-look-at-otter-blocks-custom-css-component/#post-17438386