### PR TITLE
Add unsupported blocks message

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ You can add a custom selector via a PHP constant. It requires setting a type (ty
 - Feature: Adds support for top level nesting
 - Removes the code example on focus and adds it back on blur (if empty)
 - Lets users define an additional block selector
+- Adds a notice that the site logo isn't currently supported
 
 = 1.1.0 - 2024-02-18 =
 - Prevent adding classes to blocks unless CSS is added


### PR DESCRIPTION
There doesn't seem to be a convenient way to add classes to the site logo block. It uses a render function that doens't add them in

https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/site-logo/index.php#L64C10-L64C47

It might not be possible to add support, but I'll revisit it later. For now I've added a notice to users. This might affect other blocks too that take the same approach (and are likely older blocks), but will revisit that later as well.

![CleanShot 2024-02-20 at 14 17 03@2x](https://github.com/KevinBatdorf/pattern-css/assets/1478421/b17891be-d9d1-4456-8efd-08345230ca07)

Related issue: https://wordpress.org/support/topic/not-inlining-css-on-site-logo-block/
