### PR TITLE
Release 1.2.0

### DIFF
--- a/pattern-css.php
+++ b/pattern-css.php
@@ -4,7 +4,7 @@
  * Description:       Lightening Fast, Safe, In-editor CSS Optimization and Minification Tool
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            Kevin Batdorf
  * Author URI:        https://twitter.com/kevinbatdorf
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ You can add a custom selector via a PHP constant. It requires setting a type (ty
 == Changelog ==
 
 = 1.2.0 - 2024-02-20 =
-- Feature: Adds support for top level nesting
+- Feature: Adds support for CSS nesting
 - Removes the code example on focus and adds it back on blur (if empty)
 - Lets users define an additional block selector
 - Adds a notice that the site logo isn't currently supported

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              css, styles, stylesheet, custom, blocks, pattern, design
 Tested up to:      6.5
-Stable tag:        1.1.0
+Stable tag:        1.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -110,6 +110,7 @@ You can add a custom selector via a PHP constant. It requires setting a type (ty
 
 == Changelog ==
 
+= 1.2.0 - 2024-02-20 =
 - Feature: Adds support for top level nesting
 - Removes the code example on focus and adds it back on blur (if empty)
 - Lets users define an additional block selector


### PR DESCRIPTION
- Feature: Adds support for top level CSS nesting
- Removes the code example on focus and adds it back on blur (if empty)
- Lets users define an additional block selector
- Adds a notice that the site logo isn't currently supported