### PR TITLE
Add additional check for attributes

### DIFF
--- a/pattern-css.php
+++ b/pattern-css.php
@@ -4,7 +4,7 @@
  * Description:       Lightening Fast, Safe, In-editor CSS Optimization and Minification Tool
  * Requires at least: 6.0
  * Requires PHP:      7.0
- * Version:           1.2.4
+ * Version:           1.2.5
  * Author:            Kevin Batdorf
  * Author URI:        https://twitter.com/kevinbatdorf
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              css, styles, inline, margin, pattern
 Tested up to:      6.6
-Stable tag:        1.2.4
+Stable tag:        1.2.5
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -130,6 +130,9 @@ Add this to functions.php:
 3. Will warn you if your CSS is invalid
 
 == Changelog ==
+
+= 1.2.5 - 2024-07-28 =
+- Fixed a small bug where a block may not have attributes when we access them.
 
 = 1.2.4 - 2024-07-21 =
 - Renamed the panel to Pattern CSS to differenciate it from the core panel on FSE

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ addFilter(
 		};
 		return {
 			...settings,
-			attributes: { ...settings.attributes, ...blockAttributes },
+			attributes: { ...(settings?.attributes ?? {}), ...blockAttributes },
 		};
 	},
 );


### PR DESCRIPTION
Fixes an issue where a block without attributes fails to load.

Someone reported the following:

> almost widgets, (wp default widget and thirdparty)
> Error loading block: Invalid parameter(s): attributes

Waiting on more feedback, but two things come to mind:
1. Some blocks don't have attributes passed in?
2. Older version of WordPress?

Coudl be something else too. 

The report was from someone non-native English speaking, so the error message could also be translated. The current change here I have is to just check if attributes is on the object before merging this update in, but I may want to just not return any attibutes at all (and maybe unload the slot) in some cases.

Will wait to see if there is a follow up so I can reproduce it. 