### PR TITLE
Release 1.4.0

### DIFF
--- a/pattern-css.php
+++ b/pattern-css.php
@@ -4,7 +4,7 @@
  * Description:       Lightening Fast, Safe, In-editor CSS Optimization and Minification Tool
  * Requires at least: 6.7
  * Requires PHP:      7.0
- * Version:           1.3.0
+ * Version:           1.4.0
  * Author:            Kevin Batdorf
  * Author URI:        https://twitter.com/kevinbatdorf
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Pattern CSS - The CSS Editor For Blocks ===
 Contributors:      kbat82
 Tags:              css, styles, inline, margin, editor
-Tested up to:      6.7
-Stable tag:        1.3.0
+Tested up to:      6.8
+Stable tag:        1.4.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -135,6 +135,11 @@ Add this to functions.php:
 3. Will warn you if your CSS is invalid
 
 == Changelog ==
+
+= 1.4.0 - 2025-05-12 =
+- Adds a draggable, resizable popout mode
+- Updates CSS engine to include recent CSS features
+- Allows "supports" support scoped to the block
 
 = 1.3.0 - 2025-01-27 =
 - Switches to useStyleOverride for injecting styles

--- a/src/state/popout.ts
+++ b/src/state/popout.ts
@@ -1,4 +1,3 @@
-// use zustand for x,y coordinates
 import { create } from 'zustand';
 import { persist, devtools } from 'zustand/middleware';
 


### PR DESCRIPTION
= 1.4.0 - 2025-05-12 =
- Adds a draggable, resizable popout mode
- Updates CSS engine to include recent CSS features
- Allows "supports" support scoped to the block
