### PR TITLE
Remove id on empty css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test-results/
 
 /vendor/
 tsconfig.tsbuildinfo
+
+.claude

--- a/pattern-css.php
+++ b/pattern-css.php
@@ -5,7 +5,7 @@
  * Description:       Lightening Fast, Safe, In-editor CSS Optimization and Minification Tool
  * Requires at least: 6.7
  * Requires PHP:      7.0
- * Version:           1.5.5
+ * Version:           1.5.6
  * Author:            Kevin Batdorf
  * Author URI:        https://twitter.com/kevinbatdorf
  * License:           GPL-2.0-or-later

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              block, css, styles, inline, editor
 Tested up to:      7.0
-Stable tag:        1.5.5
+Stable tag:        1.5.6
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -148,6 +148,9 @@ Once enabled, the ID field in the Advanced panel becomes editable. Type your des
 4. Works with reusable and synced patterns
 
 == Changelog ==
+
+= 1.5.6 - 2026-04-11 =
+- Removes class ID from block when CSS is cleared
 
 = 1.5.5 - 2026-03-24 =
 - Added manual class ID override (opt-in via constant)

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -192,7 +192,7 @@ export const BlockControl = (
 		if (!css?.trim()) {
 			const existing = existingClasses?.split(' ') || [];
 			const cleaned = existing
-				.filter((c: string) => !c.startsWith('pcss-'))
+				.filter((c: string) => c !== pcssClassId)
 				.join(' ');
 			setAttributes({
 				pcssAdditionalCss: '',

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -188,7 +188,21 @@ export const BlockControl = (
 	}, [transformed]);
 
 	useEffect(() => {
-		if (css === undefined) return;
+		// If CSS is empty, remove the ID and class
+		if (!css?.trim()) {
+			const existing = existingClasses?.split(' ') || [];
+			const cleaned = existing
+				.filter((c: string) => !c.startsWith('pcss-'))
+				.join(' ');
+			setAttributes({
+				pcssAdditionalCss: '',
+				pcssAdditionalCssCompiled: '',
+				pcssClassId: '',
+				className: cleaned || undefined,
+			});
+			return;
+		}
+
 		setAttributes({
 			pcssAdditionalCss: css,
 			pcssClassId: pcssClassId || `pcss-${blockId?.split('-')[0]}`,

--- a/tests/default/pattern-css.spec.ts
+++ b/tests/default/pattern-css.spec.ts
@@ -252,6 +252,17 @@ test.describe('Pattern CSS (Block)', () => {
 			page.locator('[data-cy="pcss-editor-block"] pre .line-error'),
 		).not.toBeVisible();
 
+		// Wait for the WASM transform to finish and the style to apply
+		await expect(async () => {
+			const compiled = await page.evaluate(() => {
+				const blocks = window.wp.data
+					.select('core/block-editor')
+					.getBlocks();
+				return blocks[0]?.attributes?.pcssAdditionalCssCompiled ?? '';
+			});
+			expect(compiled).toContain('#9bc882');
+		}).toPass({ timeout: 10000 });
+
 		const className = await page.evaluate(() => {
 			const blocks = window.wp.data
 				.select('core/block-editor')
@@ -271,7 +282,7 @@ test.describe('Pattern CSS (Block)', () => {
 		// Error line should appear
 		await expect(
 			page.locator('[data-cy="pcss-editor-block"] pre .line-error'),
-		).toBeVisible();
+		).toBeVisible({ timeout: 10000 });
 
 		// Color should still be the valid one, not changed
 		await expect(editorCanvas.locator(`.${className}`)).toHaveCSS(
@@ -384,6 +395,74 @@ test.describe('Pattern CSS (Block)', () => {
 		await expect(
 			page.getByLabel('Editor settings').getByText('Another block on this page is using the same ID'),
 		).toBeVisible();
+	});
+
+	test('Removes ID and class when CSS is cleared', async ({
+		admin,
+		page,
+		editor,
+	}) => {
+		await admin.createNewPost({ title: 'Test post' });
+		await editor.insertBlock({
+			name: 'core/group',
+			innerBlocks: [
+				{ name: 'core/paragraph', attributes: { content: 'Hello' } },
+			],
+		});
+
+		const editorCanvas = page
+			.locator('iframe[name="editor-canvas"]')
+			.contentFrame();
+
+		// 1. No pcss class should exist before adding CSS
+		const blockId = await page.evaluate(() => {
+			const blocks = window.wp.data
+				.select('core/block-editor')
+				.getBlocks();
+			return blocks[0]?.clientId;
+		});
+		const expectedClass = `pcss-${blockId?.split('-')[0]}`;
+
+		await expect(
+			editorCanvas.locator(`.wp-block-group.${expectedClass}`),
+		).not.toBeVisible();
+
+		// Select the block and open Pattern CSS panel
+		await editor.selectBlocks(
+			editorCanvas.locator('.wp-block-group').first(),
+		);
+		await page.getByRole('button', { name: 'Pattern CSS' }).click();
+
+		// 2. Type CSS and confirm the ID is added
+		const cssEditor = page.locator(
+			'[data-cy="pcss-editor-block"] textarea',
+		);
+		await cssEditor.fill('[block] { color: rgb(155, 200, 130); }');
+
+		await expect(async () => {
+			const attrs = await page.evaluate(() => {
+				const blocks = window.wp.data
+					.select('core/block-editor')
+					.getBlocks();
+				return blocks[0]?.attributes;
+			});
+			expect(attrs?.pcssClassId).toBeTruthy();
+			expect((attrs?.className as string) ?? '').toContain('pcss-');
+		}).toPass({ timeout: 10000 });
+
+		// 3. Clear the CSS and confirm the ID is removed
+		await cssEditor.fill('');
+
+		await expect(async () => {
+			const attrs = await page.evaluate(() => {
+				const blocks = window.wp.data
+					.select('core/block-editor')
+					.getBlocks();
+				return blocks[0]?.attributes;
+			});
+			expect(attrs?.pcssClassId).toBeFalsy();
+			expect((attrs?.className as string) ?? '').not.toContain('pcss-');
+		}).toPass({ timeout: 10000 });
 	});
 
 	test('Generate New ID resolves duplicate warning', async ({


### PR DESCRIPTION
This removes the id when you remove the css

Reference: https://wordpress.org/support/topic/bug-i-cant-remove-a-class-from-the-additional-css-classes-field