### PR TITLE
Fix flaky tests and node version

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -42,7 +42,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: lts/*
         cache: 'npm'
 
     - run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: lts/*
         cache: 'npm'
 
     - run: npm ci --prefer-offline --no-audit --no-fund

--- a/tests/default/pattern-css.spec.ts
+++ b/tests/default/pattern-css.spec.ts
@@ -108,6 +108,7 @@ test.describe('Pattern CSS (Block)', () => {
 		await expect(editorCanvas.locator(`.${className} > p`)).toHaveCSS(
 			'color',
 			'rgb(155, 200, 130)',
+			{ timeout: 10000 },
 		);
 
 		// Second block's paragraph should NOT have the color
@@ -153,6 +154,7 @@ test.describe('Pattern CSS (Block)', () => {
 		await expect(editorCanvas.locator(`.${className}`)).toHaveCSS(
 			'color',
 			'rgb(155, 200, 130)',
+			{ timeout: 10000 },
 		);
 	});
 
@@ -214,12 +216,13 @@ test.describe('Pattern CSS (Block)', () => {
 		await expect(editorCanvas.locator(`.${classNames[0]} p`)).toHaveCSS(
 			'color',
 			'rgb(155, 200, 130)',
+			{ timeout: 10000 },
 		);
 
 		// Second block should be blue
 		await expect(
 			editorCanvas.locator(`.${classNames[1]} p`).first(),
-		).toHaveCSS('color', 'rgb(0, 0, 255)');
+		).toHaveCSS('color', 'rgb(0, 0, 255)', { timeout: 10000 });
 	});
 
 	test('Shows error on invalid CSS and does not persist it', async ({

--- a/tests/default/pattern-css.spec.ts
+++ b/tests/default/pattern-css.spec.ts
@@ -144,6 +144,17 @@ test.describe('Pattern CSS (Block)', () => {
 		);
 		await cssEditor.fill('[block] { color: rgb(155, 200, 130); }');
 
+		// Wait for WASM compilation to finish
+		await expect(async () => {
+			const compiled = await page.evaluate(() => {
+				const blocks = window.wp.data
+					.select('core/block-editor')
+					.getBlocks();
+				return blocks[0]?.attributes?.pcssAdditionalCssCompiled ?? '';
+			});
+			expect(compiled).toContain('#9bc882');
+		}).toPass({ timeout: 10000 });
+
 		const className = await page.evaluate(() => {
 			const blocks = window.wp.data
 				.select('core/block-editor')


### PR DESCRIPTION
## Summary
- Change `node-version: 22` to `node-version: lts/*` in both `playwright.yml` and `playwright-nightly.yml` workflows to follow project standards
- Add `{ timeout: 10000 }` to `toHaveCSS` assertions that check dynamically compiled CSS (via WASM), which can fail intermittently when WASM compilation hasn't finished within the default timeout

## Test plan
- [ ] Verify CI workflows run with the LTS node version
- [ ] Confirm Playwright tests pass without flaky failures on WASM-dependent assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)